### PR TITLE
Fix PHP error when step is undefined

### DIFF
--- a/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
+++ b/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
@@ -97,7 +97,7 @@ final class InitializedContextEnvironment implements ContextEnvironment, Service
      */
     public function hasContextClass($class)
     {
-        return (bool) $this->resolveContextClass($class);
+        return $class ? (bool) $this->resolveContextClass($class) : false;
     }
 
     /**


### PR DESCRIPTION
## Steps to recreate:
Write a feature file with an undefined step
Execute the feature file with Behat

## Expected Behavior
Behat should warn that the suite has undefined steps, and ask you to choose a context to generate the snippet.

## Actual Behavior
The following PHP fatal error occurs:

```
PHP Fatal error:  Class name must be a valid object or a string in /var/www/vendor/behat/behat/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php on line 118
PHP Fatal Error.
Details: Array
(
    [type] => 1
    [message] => Class name must be a valid object or a string
    [file] => /var/www/vendor/behat/behat/src/Behat/Behat/Context/Environment/InitializedContextEnvironment.php
    [line] => 118
)
Stack trace: Array
(
    [0] => Array
        (
            [file] => /var/www/bin/behat
            [line] => 33
            [function] => fatalHandler
            [args] => Array
                (
                )

        )

    [1] => Array
        (
            [function] => {closure}
            [args] => Array
                (
                )

        )

)
```

## Cause
The Behat\Behat\Context\Snippet\Generator\FixedContextIdentifier class is being initialized with an empty string. When a snippet is undefined, the system attempts to present a list of all of the available contexts to generate the snippet within. One of the contexts that the system tries to list is the context defined in Behat\Behat\Context\Snippet\Generator\FixedContextIdentifier. Since this is an empty string, it causes a PHP error when passed to resolveContextClass() via hasContextClass().

## Fix
Add a falsy check on the class parameter to hasContextClass(), and return false the param is falsy rather than passing it to resolveContextClass().